### PR TITLE
Tweak appearance of job table to account for long job IDs

### DIFF
--- a/.changeset/chilly-beans-chew.md
+++ b/.changeset/chilly-beans-chew.md
@@ -1,0 +1,5 @@
+---
+"@queuedash/ui": minor
+---
+
+Improve UI support for long job ids

--- a/packages/ui/src/components/JobTable.tsx
+++ b/packages/ui/src/components/JobTable.tsx
@@ -67,11 +67,11 @@ const columns = [
   columnHelper.accessor("name", {
     cell: (props) => (
       <div className="flex w-full items-center space-x-2">
-        <span className="max-w-fit flex-1 truncate text-slate-900 dark:text-slate-200">
+        <span className="max-w-fit grow basis-full truncate text-slate-900 dark:text-slate-200">
           {props.cell.row.original.name}
         </span>
 
-        <span className="rounded-md text-sm text-slate-500 dark:text-slate-400">
+        <span className="shrink truncate max-w-[20%] text-sm text-slate-500 dark:text-slate-400">
           #{props.cell.row.original.id}
         </span>
       </div>


### PR DESCRIPTION
This occurs for example with scheduled jobs in BullMQ

<img width="1460" alt="Screenshot 2024-08-28 at 3 18 39 PM" src="https://github.com/user-attachments/assets/3b5cd003-94c1-4bcb-a026-58aa56f65f53">
