### PR TITLE
Support queue configuration from file for docker container

### DIFF
--- a/.changeset/spicy-falcons-shave.md
+++ b/.changeset/spicy-falcons-shave.md
@@ -1,5 +1,7 @@
 ---
-"@queuedash/docker": minor
+"@queuedash/ui": minor
+"@queuedash/api": minor
+"@queuedash/client": minor
 ---
 
 Support queue configuration from file for docker container

--- a/packages/docker/main.mjs
+++ b/packages/docker/main.mjs
@@ -23,11 +23,11 @@ const getConfigJson = () => {
   }
 
   if (process.env.QUEUES_CONFIG_FILE_PATH) {
-    return readFileSync(process.env.QUEUES_CONFIG_FILE);
+    return readFileSync(process.env.QUEUES_CONFIG_FILE_PATH, "utf-8");
   }
 
   throw new Error(
-    "Either QUEUES_CONFIG_JSON or QUEUES_CONFIG_FILE environment variables must be set",
+    "Either QUEUES_CONFIG_JSON or QUEUES_CONFIG_FILE_PATH environment variables must be set",
   );
 };
 


### PR DESCRIPTION
See https://github.com/alexbudure/queuedash/issues/91

# Summary

This MR adds support for loading queue configuration from a file via a new environment variable:
QUEUES_CONFIG_FILE_PATH.

If this variable is set, QueueDash will read the configuration from the specified file path instead of requiring the configuration to be passed inline via QUEUES_CONFIG_JSON.